### PR TITLE
Remove non-relevant config options for graphql plugin

### DIFF
--- a/config/plugins.ts
+++ b/config/plugins.ts
@@ -2,10 +2,6 @@ export default {
   graphql: {
     config: {
       defaultLimit: 100,
-      playgroundAlways: true,
-      apolloServer: {
-        introspection: true,
-      },
     },
   },
 };


### PR DESCRIPTION
Consolidate with other projects, where these settings are not explicitly mentioned in config/plugins.ts.