### PR TITLE
Switch ingress cert-manager issuer to cloudflare-dns01

### DIFF
--- a/kubernetes/base/ingress.yml
+++ b/kubernetes/base/ingress.yml
@@ -6,9 +6,8 @@ metadata:
   labels:
     service: app
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt
+    cert-manager.io/cluster-issuer: cloudflare-dns01
     cert-manager.io/issue-temporary-certificate: 'true'
-    kubernetes.io/ingress.class: haproxy
 spec:
   tls:
     - hosts:


### PR DESCRIPTION
## Summary
- Switch `cert-manager.io/cluster-issuer` from `letsencrypt` to `cloudflare-dns01`
- Remove `kubernetes.io/ingress.class: haproxy` annotation

## Test plan
- [ ] Confirm certificate issues successfully via cloudflare-dns01 issuer in staging